### PR TITLE
Maybe the bundling script can be made more reproducable

### DIFF
--- a/bundle_into_single_file.sh
+++ b/bundle_into_single_file.sh
@@ -1,2 +1,6 @@
 #!
-grep -h -v require_once Graphite.php Graphite/*.php
+
+# This script generates the "bundled" version of Graphite.php available from http://graphite.ecs.soton.ac.uk/download.php/Graphite.php
+
+echo '<?php'
+grep -h -v -e require_once -e '<?php' Graphite/Retriever.php Graphite.php Graphite/Node.php Graphite/Null.php Graphite/Resource.php Graphite/Relation.php Graphite/Description.php Graphite/InverseRelation.php Graphite/Literal.php Graphite/ResourceList.php


### PR DESCRIPTION
I tried and run the bundling script, and the order of the \* globing was apparently different.

Here's my suggestion to make it less unpredictable
