### PR TITLE
Replace deprecated /e preg_replace modifier and require PHP 5.3

### DIFF
--- a/Graphite/Literal.php
+++ b/Graphite/Literal.php
@@ -44,7 +44,9 @@ class Graphite_Literal extends Graphite_Node
 		$v = preg_replace( "/\t/", "<span class='special_char' style='font-size:70%'>[tab]</span>", $v );
 		$v = preg_replace( "/\n/", "<span class='special_char' style='font-size:70%'>[nl]</span><br />", $v );
 		$v = preg_replace( "/\r/", "<span class='special_char' style='font-size:70%'>[cr]</span>", $v );
-		$v = preg_replace( "/  +/e", "\"<span class='special_char' style='font-size:70%'>\".str_repeat(\"␣\",strlen(\"$0\")).\"</span>\"", $v );
+		$v = preg_replace_callback( "/  +/", function($matches) {
+			return "<span class='special_char' style='font-size:70%'>" . str_repeat("␣", strlen($matches[0])) . "</span>";
+		}, $v);
 		$r = '"'.$v.'"';
 
 		if( isset($this->triple["l"]) && $this->triple["l"])

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         }
     ],
     "require": {
-        "semsol/arc2": "dev-master"
+        "semsol/arc2": "dev-master",
+        "php": ">=5.3.0"
     },
     "autoload": {
         "files": ["Graphite.php"]


### PR DESCRIPTION
- The /e modifier was deprecated in PHP 5.5
- Using preg_replace_callback with anonymous functions, added in PHP 5.3